### PR TITLE
Update async-search.py

### DIFF
--- a/workflows/async-search/python/async-search.py
+++ b/workflows/async-search/python/async-search.py
@@ -117,7 +117,7 @@ def run():
         x = askedDict[xstring]
         y = data['cost']
         if math.isnan(y):
-            y[:]=1e6
+            y[:]=math.MaxFloat64
         opt.tell(x, y)
         #source = status.Get_source()
         #tag = status.Get_tag()

--- a/workflows/async-search/python/async-search.py
+++ b/workflows/async-search/python/async-search.py
@@ -7,6 +7,8 @@ from skopt import Optimizer
 import as_problem as problem
 import datetime
 import math
+import sys
+
 # list of ga_utils parameter objects
 problem_params = None
 
@@ -117,7 +119,7 @@ def run():
         x = askedDict[xstring]
         y = data['cost']
         if math.isnan(y):
-            y[:]=math.MaxFloat64
+            y=sys.float_info.max
         opt.tell(x, y)
         #source = status.Get_source()
         #tag = status.Get_tag()

--- a/workflows/async-search/python/async-search.py
+++ b/workflows/async-search/python/async-search.py
@@ -6,7 +6,7 @@ import numpy as np
 from skopt import Optimizer
 import as_problem as problem
 import datetime
-
+import math
 # list of ga_utils parameter objects
 problem_params = None
 
@@ -116,6 +116,8 @@ def run():
         xstring = data['x']
         x = askedDict[xstring]
         y = data['cost']
+        if math.isnan(y):
+            y[:]=1e6
         opt.tell(x, y)
         #source = status.Get_source()
         #tag = status.Get_tag()


### PR DESCRIPTION
sklearn expects a float64, when a NaN is returned by a failed run
- causes big jobs to fails, when evaluating bad set of hyperparameters