### PR TITLE
model_runner: avoid adding None to $PATH when $MODEL_PYTHON_DIR not set

### DIFF
--- a/workflows/common/python/model_runner.py
+++ b/workflows/common/python/model_runner.py
@@ -16,8 +16,15 @@ logger = None
 
 print("MODEL RUNNER...")
 
-sys.path.append(os.getenv("BENCHMARKS_ROOT")+"/common")
-sys.path.append(os.getenv("MODEL_PYTHON_DIR"))
+# append ${BENCHMARKS_ROOT}/common to $PATH if variable is set
+benchmarks_root = os.getenv("BENCHMARKS_ROOT")
+if benchmarks_root:
+  sys.path.append(benchmarks_root+"/common")
+
+# append ${MODEL_PYTHON_DIR} to $PATH if variable is set
+python_dir = os.getenv("MODEL_PYTHON_DIR")
+if python_dir:
+  sys.path.append(python_dir)
 
 print("sys.path:")
 print(sys.path)


### PR DESCRIPTION
If $MODEL_PYTHON_DIR is not set, None would be added to the list of entries in the sys.path array.  This would then lead to an error when searching for python modules, which is reported in an experiments/X*/run/test0/model.log file:

```
TypeError: zipimporter() argument 1 must be string, not None
```

This commit avoids adding entries for $BENCHMARKS_ROOT and $MODEL_PYTHON_DIR if those variables are not set.

If those variables are required to be set, perhaps an error message could be printed here as well?