### PR TITLE
upf: drop TURBINE_LAUNCH_OPTIONS from workflow.sh

### DIFF
--- a/workflows/upf/swift/workflow.sh
+++ b/workflows/upf/swift/workflow.sh
@@ -77,7 +77,6 @@ mkdir -pv $TURBINE_OUTPUT/run
 
 # Used by init.sh to copy the UPF to TURBINE_OUTPUT
 export UPF
-export TURBINE_LAUNCH_OPTIONS="-cc none"
 
 swift-t -n $PROCS \
         ${MACHINE:-} \


### PR DESCRIPTION
The ups workflow.sh was setting a site-specific option for TURBINE_LAUNCH_OPTIONS.  This drops that setting.
```
export TURBINE_LAUNCH_OPTIONS="-cc none"
```
I believe it was added for theta, so perhaps it could be added back to workflows/common/sh/sched-theta.sh.  I decided not to do that here, since I can't test whether doing so would break jobs submitted theta.
