### PR TITLE
Adding script to run one-shot NT3 benchmark with Tensorflow 2.0

### DIFF
--- a/workflows/one-shot/job-tf2.sh
+++ b/workflows/one-shot/job-tf2.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -l
+set -eu
+
+# JOB SH
+
+echo $( basename $0 )
+hostname
+
+source /opt/modules/default/init/bash
+module load modules
+PATH=/opt/cray/elogin/eproxy/2.0.14-4.3/bin:$PATH # For aprun
+module load alps
+
+set -x
+aprun -n 1 -N 1 $THIS/run-nt3-tf2.sh

--- a/workflows/one-shot/run-nt3-tf2.sh
+++ b/workflows/one-shot/run-nt3-tf2.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -l
+# Need -l to reset modules ...
+set -eu
+
+# RUN NT3
+
+echo $( basename $0 )
+hostname
+
+# Modules start
+module unload cray-python/3.6.5.3
+module load   datascience/tensorflow-2.0
+# Modules end
+
+which python
+
+# Report original source directory
+echo THIS=$THIS
+
+BENCHMARKS=$( readlink --canonicalize $THIS/../../../Benchmarks )
+NT3=$BENCHMARKS/Pilot1/NT3/nt3_baseline_keras2.py
+
+set -x
+python $NT3 --epochs 1

--- a/workflows/one-shot/submit-tf2.sh
+++ b/workflows/one-shot/submit-tf2.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -l
+set -eu
+
+# SUBMIT SH
+
+THIS=$( readlink --canonicalize $( dirname $0 ) )
+
+DIRECTORY=$THIS
+OUTPUT=$THIS/output.txt
+
+source $THIS/settings.sh
+
+if [[ -f $OUTPUT ]]
+then
+  mv --backup=numbered $OUTPUT $OUTPUT.bak
+fi
+
+set -x
+qsub -n $WORKERS \
+     -t $WALLTIME \
+     -A $PROJECT \
+     -q $QUEUE \
+     -o $OUTPUT \
+     -e $OUTPUT \
+     --env THIS=$THIS \
+     --cwd $DIRECTORY \
+     --jobname $JOBNAME \
+     $THIS/job-tf2.sh


### PR DESCRIPTION
This PR is the counterpart of https://github.com/ECP-CANDLE/Benchmarks/pull/56, which adds support for Tensorflow 2.0 in an NT3 model. It adds a few scripts that load tensorflow 2.0 on Theta instead of tensorflow 1.14.