### PR TITLE
Put back in a few changes to env-summit-tf1.sh which used to be env-s…

### DIFF
--- a/workflows/common/sh/cfg-sys-summit-tf1.sh
+++ b/workflows/common/sh/cfg-sys-summit-tf1.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# UPF CFG SYS 1
+
+# The number of MPI processes
+# Note that 1 process is reserved for Swift/T
+# For example, if PROCS=4 that gives you 3 workers,
+# i.e., 3 concurrent Keras runs.
+export PROCS=${PROCS:-2}
+
+# MPI processes per node.  This should not exceed PROCS.
+# Cori has 32 cores per node, 128GB per node
+export PPN=${PPN:-1}
+
+#export QUEUE=${QUEUE:-batch}
+
+# Cori: (cf. sched-cori)
+# export QUEUE=${QUEUE:-debug}
+# Cori queues: debug, regular
+# export QUEUE=regular
+# export QUEUE=debug
+# CANDLE on Cori:
+# export PROJECT=m2924
+
+# Theta: (cf. sched-theta)
+# export QUEUE=${QUEUE:-debug-cache-quad}
+#export QUEUE=${QUEUE:-debug-flat-quad}
+# export PROJECT=${PROJECT:-ecp-testbed-01}
+# export PROJECT=Candle_ECP
+#export PROJECT=CSC249ADOA01
+
+# Summit:
+export QUEUE=${QUEUE:-batch}
+
+export PROJECT=${PROJECT:-med106}
+
+export WALLTIME=${WALLTIME:-0:30}
+
+# export MAIL_ENABLED=1
+# export MAIL_ADDRESS=wozniak@mcs.anl.gov
+
+# Benchmark run timeout: benchmark run will timeout
+# after the specified number of seconds. -1 is no timeout.
+BENCHMARK_TIMEOUT=${BENCHMARK_TIMEOUT:-3600} # probably not needed but this variable is baked into rest of code, e.g., workflow.sh
+
+# Uncomment below to use custom python script to run
+# Use file name without .py (e.g, my_script.py)
+# BENCHMARK_DIR=/path/to/
+# MODEL_PYTHON_SCRIPT=my_script
+
+# Shell timeout: benchmark run will be killed
+# after the specified number of seconds.
+# If set to -1 or empty there is no timeout.
+# This timeout is implemented with the shell command 'timeout'
+export SH_TIMEOUT=${SH_TIMEOUT:-}
+
+# Ignore errors: If 1, unknown errors will be reported to model.log
+# but will not bring down the Swift workflow.  See model.sh .
+export IGNORE_ERRORS=0

--- a/workflows/common/sh/env-summit-tf1.sh
+++ b/workflows/common/sh/env-summit-tf1.sh
@@ -49,10 +49,15 @@ R=/gpfs/alpine/world-shared/med106/wozniak/sw/gcc-6.4.0/R-3.6.1/lib64/R
 LD_LIBRARY_PATH+=:$R/lib
 
 PY=/gpfs/alpine/world-shared/med106/sw/condaenv-200408
+LD_LIBRARY_PATH+=:/lib64 # we need this path to be before the $PY/lib one, which is added right below, or else for compiling using mpicc we get the error "/usr/bin/uuidgen: /gpfs/alpine/world-shared/med106/sw/condaenv-200408/lib/libuuid.so.1: no version information available (required by /usr/bin/uuidgen)"
 LD_LIBRARY_PATH+=:$PY/lib
 export PYTHONHOME=$PY
 
-export LD_LIBRARY_PATH=/gpfs/alpine/world-shared/med106/sw/condaenv-200408/lib:$LD_LIBRARY_PATH
+# ALW 11/12/20: Again, this path is already added, albeit to the end rather than the beginning, in the LD_LIBRARY_PATH+=:$PY/lib line above
+#export LD_LIBRARY_PATH=/gpfs/alpine/world-shared/med106/sw/condaenv-200408/lib:$LD_LIBRARY_PATH
+
+# ALW 11/12/20: Again, adding this per Justin and my experiments and discussion on 9/30/20 and 10/1/20
+export LD_LIBRARY_PATH="/sw/summit/gcc/6.4.0/lib64:$LD_LIBRARY_PATH"
 
 # EMEWS Queues for R
 EQR=$MED106/wozniak/sw/gcc-6.4.0/EQ-R

--- a/workflows/common/sh/env-summit-tf1.sh
+++ b/workflows/common/sh/env-summit-tf1.sh
@@ -49,15 +49,10 @@ R=/gpfs/alpine/world-shared/med106/wozniak/sw/gcc-6.4.0/R-3.6.1/lib64/R
 LD_LIBRARY_PATH+=:$R/lib
 
 PY=/gpfs/alpine/world-shared/med106/sw/condaenv-200408
-LD_LIBRARY_PATH+=:/lib64 # we need this path to be before the $PY/lib one, which is added right below, or else for compiling using mpicc we get the error "/usr/bin/uuidgen: /gpfs/alpine/world-shared/med106/sw/condaenv-200408/lib/libuuid.so.1: no version information available (required by /usr/bin/uuidgen)"
 LD_LIBRARY_PATH+=:$PY/lib
 export PYTHONHOME=$PY
 
-# ALW 11/12/20: Again, this path is already added, albeit to the end rather than the beginning, in the LD_LIBRARY_PATH+=:$PY/lib line above
-#export LD_LIBRARY_PATH=/gpfs/alpine/world-shared/med106/sw/condaenv-200408/lib:$LD_LIBRARY_PATH
-
-# ALW 11/12/20: Again, adding this per Justin and my experiments and discussion on 9/30/20 and 10/1/20
-export LD_LIBRARY_PATH="/sw/summit/gcc/6.4.0/lib64:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH=/gpfs/alpine/world-shared/med106/sw/condaenv-200408/lib:$LD_LIBRARY_PATH
 
 # EMEWS Queues for R
 EQR=$MED106/wozniak/sw/gcc-6.4.0/EQ-R


### PR DESCRIPTION
…ummit.sh: added /lib64 back into LD_LIBRARY_PATH prior to the addition of $PY/lib; removed redundant and differently placed $PY/lib to the beginning of LD_LIBRARY_PATH below; and added back in the gcc library paths to LD_LIBRARY_PATH to the beginning in order to make Swift/T work