### PR TITLE
Updated langs-app-biowulf.sh with correct Python module variable and …

### DIFF
--- a/workflows/common/sh/langs-app-biowulf.sh
+++ b/workflows/common/sh/langs-app-biowulf.sh
@@ -1,9 +1,9 @@
 
-# LANGS APP Singularity on Biowulf
-# Language settings for singularity app functions (Python, R, etc.)
+# LANGS APP Biowulf
+# Language settings for app functions (Python, R, etc.)
 
 # Load the environment in which CANDLE was built
-module load $DEFAULT_PYTHON_MODULE
+module load "$CANDLE_DEFAULT_PYTHON_MODULE"
 
 #module load openmpi/3.1.2/cuda-9.0/gcc-7.3.0-pmi2 cuDNN/7.1/CUDA-9.0 CUDA/9.0
 #source /data/$USER/conda/etc/profile.d/conda.sh

--- a/workflows/mlrMBO/swift/workflow.sh
+++ b/workflows/mlrMBO/swift/workflow.sh
@@ -132,8 +132,8 @@ fi
 
 site2=$(echo $SITE | awk -v FS="-" '{print $1}') # ALW 2020-11-15: allow $SITEs to have hyphens in them as Justin implemented for Summit on 2020-10-29, e.g., summit-tf1
 
-# Use for Summit (LSF needs two %)
-if [[ ${site2:-} == "summit" ]]
+# Use for Summit (LSF needs two %)... actually, it may not be LSF as Biowulf (which uses SLURM) seems to need this too now
+if [ ${site2:-} == "summit" ] || [ ${site2:-} == "biowulf" ]
 then
   export TURBINE_STDOUT="$TURBINE_OUTPUT/out/out-%%r.txt"
 else


### PR DESCRIPTION
…forced Biowulf to use two percent signs in mlrMBO workflow.sh just like Summit